### PR TITLE
Fix: return proper value for `random_batch` method of `ReplayPool`

### DIFF
--- a/UtilsRL/rl/buffer.py
+++ b/UtilsRL/rl/buffer.py
@@ -154,7 +154,7 @@ class TransitionReplayPool(ReplayPool):
         samples = {
             field_name: self.fields[field_name][idx] for field_name in fields
         }
-        return samples, idx if return_idx else samples
+        return (samples, idx) if return_idx else samples
         
     def random_indices(self, batch_size):
         if self._size == 0: 
@@ -242,7 +242,7 @@ class TrajectoryReplayPool(ReplayPool):
         samples = {
             field_name: self.fields[field_name][idx] for field_name in fields
         }
-        return samples, idx if return_idx else samples
+        return (samples, idx) if return_idx else samples
         
     def random_indices(self, batch_size):
         if self._size == 0: 
@@ -305,7 +305,7 @@ class PrioritizedReplayPool(TransitionReplayPool):
         samples = {
             field_name: self.fields[field_name][idx] for field_name in fields
         }
-        return samples, idx if return_idx else samples
+        return (samples, idx) if return_idx else samples
         
     def random_indices(self, batch_size, return_value=False):
         if self._size == 0:


### PR DESCRIPTION
https://github.com/typoverflow/UtilsRL/blob/3d52ea246eefa81ac7747507bdb2ef9aa5202915/UtilsRL/rl/buffer.py#L157

The code above will return `(samples, idx)` when `return_idx=True` and `(samples, samples)` when `return_idx=False`. However, it seems that it should return only `samples` when `return_idx=False`, following the code in the example:

https://github.com/typoverflow/UtilsRL/blob/3d52ea246eefa81ac7747507bdb2ef9aa5202915/examples/train_ppo_mujoco.py#L213-L214

and the example code will raise a `TypeError`:

```
Traceback (most recent call last):
  File ".../UtilsRL/examples/train_ppo_mujoco.py", line 214, in <module>
    data_batch["obs"] = obs_normalizer.transform(torch.from_numpy(data_batch["obs"]).to(torch_ftype).to(args.device)).cpu().numpy()
TypeError: tuple indices must be integers or slices, not str
```

Consider simply changing the `return` line to fix this bug.

```Python
    return (samples, idx) if return_idx else samples
```

Require review and discussion of this issue (maybe it is fixed in other branches?).

